### PR TITLE
Add option to specify Docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ func TestCreateSpaceAndUseIt(t *testing.T) {
 ```
 
 You must have a directory called `1-singlespace` as a sibling to the directory called in the `Act` method. This directory
-must contain a Terraform module that creates a new Octopus space and returns the new space ID as teh output variable `octopus_space_id`.
+must contain a Terraform module that creates a new Octopus space and returns the new space ID as the output variable `octopus_space_id`.
 For example:
 
 ```
@@ -40,10 +40,11 @@ An example of this directory has been provided at [1-singlespace](terraform%2F1-
 ## Environment variables
 
 * `OCTOTESTWAITFORAPI` - set to `false` to remove the check of the API between creating a space and populating it. The default is to run these checks.
-* `OCTOTESTVERSION` - set to the tag of the `octopusdeploy/octopusdeploy` Docker image to use in the tests. The default is `latest`.
+* `OCTOTESTIMAGEURL` - set to the Docker image URL for the Octopus Server to use in the tests. Defaults to the public image on DockerHub (i.e. `octopusdeploy/octopusdeploy`)
+* `OCTOTESTVERSION` - set to the tag of the Docker image to use in the tests. The default is `latest`.
 * `OCTOTESTRETRYCOUNT` - set to the number of retries to use for any individual test. Defaults to 3.
 * `OCTOTESTDUMPSTATE` - set to `true` to dump the Terraform state if a request for an output variable fails. Defaults to `false`.
 * `OCTOTESTDEFAULTSPACEID` - Terraform seems to have a bug where the state file is not written correctly. If this happens, the ID of the newly created space can not be read. Setting this env var allows you to recover from this error by setting the default value of the new space (usually `Spaces-2`).
 * `OCTOTESTSKIPINIT` - set to true to skip `terraform init`. Skipping the init phase is useful when you define a provider override in the `~/.terraformrc` file.
 * `OCTODISABLEOCTOCONTAINERLOGGING` - set to true to skip logging output from the Octopus container.
-* `LICENSE` - Set to the base 64 encoded version of an Octopus XML license. See `Test Octopus License` under `Shared-Sales` in Lasptpass for a value.
+* `LICENSE` - Set to the base 64 encoded version of an Octopus XML license. See `Octopus Dev License` in 1Password for a value.

--- a/test/octopus_container_test_framework.go
+++ b/test/octopus_container_test_framework.go
@@ -204,7 +204,7 @@ func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString stri
 	if err != nil {
 		return nil, err
 	}
-	t.Log("FINISHED creating Octopus container")
+	t.Log("Finished creating Octopus container")
 
 	// Display the container logs
 	if os.Getenv("OCTODISABLEOCTOCONTAINERLOGGING") != "true" {

--- a/test/octopus_container_test_framework.go
+++ b/test/octopus_container_test_framework.go
@@ -139,6 +139,15 @@ func (o *OctopusContainerTest) setupDatabase(ctx context.Context, network string
 	}, nil
 }
 
+func (o *OctopusContainerTest) getOctopusImageUrl() string {
+	overrideImageUrl := os.Getenv("OCTOTESTIMAGEURL")
+	if overrideImageUrl != "" {
+		return overrideImageUrl
+	}
+
+	return "octopusdeploy/octopusdeploy"
+}
+
 func (o *OctopusContainerTest) getOctopusVersion() string {
 	overrideOctoTag := os.Getenv("OCTOTESTVERSION")
 	if overrideOctoTag != "" {
@@ -158,7 +167,7 @@ func (o *OctopusContainerTest) getRetryCount() uint {
 }
 
 // setupOctopus creates an Octopus container
-func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString string, network string) (*OctopusContainer, error) {
+func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString string, network string, t *testing.T) (*OctopusContainer, error) {
 	if os.Getenv("LICENSE") == "" {
 		return nil, errors.New("the LICENSE environment variable must be set to a base 64 encoded Octopus license key")
 	}
@@ -169,7 +178,7 @@ func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString stri
 
 	req := testcontainers.ContainerRequest{
 		Name:         "octopus-" + uuid.New().String(),
-		Image:        "octopusdeploy/octopusdeploy:" + o.getOctopusVersion(),
+		Image:        o.getOctopusImageUrl() + ":" + o.getOctopusVersion(),
 		ExposedPorts: []string{"8080/tcp"},
 		Env: map[string]string{
 			"ACCEPT_EULA":                   "Y",
@@ -186,6 +195,7 @@ func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString stri
 			network,
 		},
 	}
+	t.Log("Creating Octopus container")
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
@@ -194,6 +204,7 @@ func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString stri
 	if err != nil {
 		return nil, err
 	}
+	t.Log("FINISHED creating Octopus container")
 
 	// Display the container logs
 	if os.Getenv("OCTODISABLEOCTOCONTAINERLOGGING") != "true" {
@@ -249,7 +260,7 @@ func (o *OctopusContainerTest) ArrangeTest(t *testing.T, testFunc func(t *testin
 			t.Log("SQL Server IP: " + sqlIp)
 			t.Log("SQL Server Container Name: " + sqlName)
 
-			octopusContainer, err := o.setupOctopus(ctx, "Server="+sqlIp+",1433;Database=OctopusDeploy;User=sa;Password=Password01!", networkName)
+			octopusContainer, err := o.setupOctopus(ctx, "Server="+sqlIp+",1433;Database=OctopusDeploy;User=sa;Password=Password01!", networkName, t)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Backwards compatible change that allows a custom Docker registry to be specified. The registry URL defaults to the existing Octopus repo on DockerHub (public repo).

This change is needed as part of the work to allow non-GA Octopus server images to be used as part of our integration testing for the Octopus Terraform provider. See Terraform provider [PR](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/616) for context.

[sc-70106]