### PR TITLE
Stop the test Octopus container from sending telemetry

### DIFF
--- a/test/octopus_container_test_framework.go
+++ b/test/octopus_container_test_framework.go
@@ -188,6 +188,7 @@ func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString stri
 			"ADMIN_USERNAME":                "admin",
 			"ADMIN_PASSWORD":                "Password01!",
 			"OCTOPUS_SERVER_BASE64_LICENSE": os.Getenv("LICENSE"),
+			"ENABLE_USAGE":                  "N",
 		},
 		Privileged: false,
 		WaitingFor: wait.ForLog("Listening for HTTP requests on").WithStartupTimeout(30 * time.Minute),


### PR DESCRIPTION
We've been getting a lot of noise / false positives in the usage metrics in Amplitude as a result of the integration tests generating and sending analytics events.

This PR sets the [env var](https://github.com/OctopusDeploy/OctopusDeploy/blob/main/docker/linux/install.sh#L83) to stop the Octopus container from sending those events. 