### PR TITLE
Update README with the env var to stop telemetry being sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ An example of this directory has been provided at [1-singlespace](terraform%2F1-
 * `OCTOTESTSKIPINIT` - set to true to skip `terraform init`. Skipping the init phase is useful when you define a provider override in the `~/.terraformrc` file.
 * `OCTODISABLEOCTOCONTAINERLOGGING` - set to true to skip logging output from the Octopus container.
 * `LICENSE` - Set to the base 64 encoded version of an Octopus XML license. See `Octopus Dev License` in 1Password for a value.
+* `ENABLE_USAGE` - set to `N` to stop Octopus from sending telemetry.

--- a/test/octopus_container_test_framework.go
+++ b/test/octopus_container_test_framework.go
@@ -188,6 +188,7 @@ func (o *OctopusContainerTest) setupOctopus(ctx context.Context, connString stri
 			"ADMIN_USERNAME":                "admin",
 			"ADMIN_PASSWORD":                "Password01!",
 			"OCTOPUS_SERVER_BASE64_LICENSE": os.Getenv("LICENSE"),
+			"ENABLE_USAGE":                  "N",
 		},
 		Privileged: false,
 		WaitingFor: wait.ForLog("Listening for HTTP requests on").WithStartupTimeout(30 * time.Minute),


### PR DESCRIPTION
Forgot to update the README file in https://github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/pull/2