### PR TITLE
Remove testing main for arrange container call

### DIFF
--- a/test/octopus_container_test_framework.go
+++ b/test/octopus_container_test_framework.go
@@ -325,7 +325,7 @@ func (o *OctopusContainerTest) createDockerInfrastructure(t *testing.T, ctx cont
 }
 
 // ArrangeTestContainer is wrapper that initialises Octopus, and returns the container for future test runs
-func (o *OctopusContainerTest) ArrangeContainer(m *testing.M) (*OctopusContainer, *client.Client, *MysqlContainer, testcontainers.Network, error) {
+func (o *OctopusContainerTest) ArrangeContainer() (*OctopusContainer, *client.Client, *MysqlContainer, testcontainers.Network, error) {
 	var octopusContainer *OctopusContainer
 	var octoClient *client.Client
 	var network testcontainers.Network


### PR DESCRIPTION
Remove testing main requirement for Arrange Container. This was intended to enforce a single setup for test runs. We're now switching to test suites to separate out integration and unit tests.